### PR TITLE
feat(spice): Implement Op-Amp Simulation Support

### DIFF
--- a/lib/circuitJsonToSpice.ts
+++ b/lib/circuitJsonToSpice.ts
@@ -2,6 +2,7 @@ import { SpiceNetlist } from "./spice-classes/SpiceNetlist"
 import { SpiceComponent } from "./spice-classes/SpiceComponent"
 import type {
   AnyCircuitElement,
+  SimulationOpAmp,
   SimulationSwitch,
   SimulationVoltageProbe,
   SourceSimpleDiode,
@@ -21,6 +22,7 @@ import { processSimpleTransistor } from "./processors/simple-transistor"
 import { processSimulationVoltageSources } from "./processors/process-simulation-voltage-sources"
 import { processSimulationCurrentSources } from "./processors/process-simulation-current-sources"
 import { processSimulationExperiment } from "./processors/process-simulation-experiment"
+import { processSimulationOpAmps } from "./processors/process-simulation-op-amp"
 
 export function circuitJsonToSpice(
   circuitJson: AnyCircuitElement[],
@@ -37,6 +39,9 @@ export function circuitJsonToSpice(
       (element) => (element as { type?: string }).type === "simulation_switch",
     )
     .map((element) => element as unknown as SimulationSwitch)
+  const simulationOpAmps = circuitJson.filter(
+    (elm) => elm.type === "simulation_op_amp",
+  ) as SimulationOpAmp[]
   const simulationSwitchMap = new Map<string, SimulationSwitch>()
 
   for (const simSwitch of simulationSwitches) {
@@ -272,6 +277,8 @@ export function circuitJsonToSpice(
     su(circuitJson).simulation_current_source.list(),
     nodeMap,
   )
+
+  processSimulationOpAmps(netlist, simulationOpAmps, nodeMap)
 
   const simulationExperiment = circuitJson.find(
     (elm) => elm.type === "simulation_experiment",

--- a/lib/processors/process-simulation-op-amp.ts
+++ b/lib/processors/process-simulation-op-amp.ts
@@ -1,0 +1,64 @@
+import type { SimulationOpAmp } from "circuit-json"
+import { SpiceComponent } from "lib/spice-classes/SpiceComponent"
+import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
+import { SubcircuitCallCommand } from "lib/spice-commands"
+
+const OPAMP_SUBCIRCUIT_NAME = "GENERIC_OPAMP"
+const OPAMP_SUBCIRCUIT_DEFINITION = `
+.SUBCKT ${OPAMP_SUBCIRCUIT_NAME} non_inverting_input inverting_input positive_supply negative_supply output
+* Generic Op-Amp Model
+E1 internal_output 0 non_inverting_input inverting_input 100k
+Rin non_inverting_input inverting_input 10Meg
+Rout internal_output output 75
+D1 output positive_supply opamp_diode
+D2 negative_supply output opamp_diode
+.model opamp_diode D
+.ENDS ${OPAMP_SUBCIRCUIT_NAME}
+`.trim()
+
+export const processSimulationOpAmps = (
+  netlist: SpiceNetlist,
+  simulationOpAmps: SimulationOpAmp[],
+  nodeMap: Map<string, string>,
+) => {
+  if (simulationOpAmps.length === 0) return
+
+  if (!netlist.models.has(OPAMP_SUBCIRCUIT_NAME)) {
+    netlist.models.set(OPAMP_SUBCIRCUIT_NAME, OPAMP_SUBCIRCUIT_DEFINITION)
+  }
+
+  for (const simOpAmp of simulationOpAmps) {
+    if (simOpAmp.type !== "simulation_op_amp") continue
+
+    const nonInvertingInputNode =
+      nodeMap.get(simOpAmp.non_inverting_input_source_port_id) ?? "0"
+    const invertingInputNode =
+      nodeMap.get(simOpAmp.inverting_input_source_port_id) ?? "0"
+    const outputNode = nodeMap.get(simOpAmp.output_source_port_id) ?? "0"
+    const positiveSupplyNode =
+      nodeMap.get(simOpAmp.positive_supply_source_port_id) ?? "0"
+    const negativeSupplyNode =
+      nodeMap.get(simOpAmp.negative_supply_source_port_id) ?? "0"
+
+    const nodes = [
+      nonInvertingInputNode,
+      invertingInputNode,
+      positiveSupplyNode,
+      negativeSupplyNode,
+      outputNode,
+    ]
+
+    const opAmpCmd = new SubcircuitCallCommand({
+      name: simOpAmp.simulation_op_amp_id,
+      nodes,
+      subcircuitName: OPAMP_SUBCIRCUIT_NAME,
+    })
+
+    const spiceComponent = new SpiceComponent(
+      simOpAmp.simulation_op_amp_id,
+      opAmpCmd,
+      nodes,
+    )
+    netlist.addComponent(spiceComponent)
+  }
+}

--- a/tests/unit/simulation-op-amp.test.ts
+++ b/tests/unit/simulation-op-amp.test.ts
@@ -1,0 +1,62 @@
+import { test, expect } from "bun:test"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+import type { AnyCircuitElement } from "circuit-json"
+
+test("simulation op amp", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_port",
+      source_port_id: "U1_non_inverting_input",
+      name: "non_inverting_input",
+    },
+    {
+      type: "source_port",
+      source_port_id: "U1_inverting_input",
+      name: "inverting_input",
+    },
+    {
+      type: "source_port",
+      source_port_id: "U1_positive_supply",
+      name: "positive_supply",
+    },
+    {
+      type: "source_port",
+      source_port_id: "U1_negative_supply",
+      name: "negative_supply",
+    },
+    {
+      type: "source_port",
+      source_port_id: "U1_output",
+      name: "output",
+    },
+    {
+      type: "simulation_op_amp",
+      simulation_op_amp_id: "sim_op_amp_1",
+      inverting_input_source_port_id: "U1_inverting_input",
+      non_inverting_input_source_port_id: "U1_non_inverting_input",
+      output_source_port_id: "U1_output",
+      positive_supply_source_port_id: "U1_positive_supply",
+      negative_supply_source_port_id: "U1_negative_supply",
+    },
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).toContain(".SUBCKT GENERIC_OPAMP")
+  expect(spiceString).toContain("Xsim_op_amp_1 N1 N2 N3 N4 N5 GENERIC_OPAMP")
+  expect(spiceString).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    .SUBCKT GENERIC_OPAMP non_inverting_input inverting_input positive_supply negative_supply output
+    * Generic Op-Amp Model
+    E1 internal_output 0 non_inverting_input inverting_input 100k
+    Rin non_inverting_input inverting_input 10Meg
+    Rout internal_output output 75
+    D1 output positive_supply opamp_diode
+    D2 negative_supply output opamp_diode
+    .model opamp_diode D
+    .ENDS GENERIC_OPAMP
+    Xsim_op_amp_1 N1 N2 N3 N4 N5 GENERIC_OPAMP
+    .END"
+  `)
+})


### PR DESCRIPTION
This PR introduces support for simulation_op_amp elements, enabling the   
conversion of circuits with operational amplifiers into SPICE netlists.         

A generic op-amp model is added as a subcircuit (.SUBCKT), which is then        
instantiated for each op-amp in the design. This significantly expands the      
simulation capabilities of the tool.