### PR TITLE
Add SAVE statements for simulation voltage probes

### DIFF
--- a/lib/processors/process-simulation-experiment.ts
+++ b/lib/processors/process-simulation-experiment.ts
@@ -66,7 +66,9 @@ export const processSimulationExperiment = (
       nodesToProbe.size > 0 &&
       simExperiment.experiment_type?.includes("transient")
     ) {
-      netlist.printStatements.push(`.PRINT TRAN ${[...nodesToProbe].join(" ")}`)
+      const probeVectors = [...nodesToProbe].join(" ")
+      netlist.printStatements.push(`.PRINT TRAN ${probeVectors}`)
+      netlist.saveStatements.push(`.SAVE ${probeVectors}`)
     }
   }
 

--- a/lib/spice-classes/SpiceNetlist.ts
+++ b/lib/spice-classes/SpiceNetlist.ts
@@ -11,6 +11,7 @@ export class SpiceNetlist {
   models: Map<string, string>
   tranCommand: string | null
   printStatements: string[]
+  saveStatements: string[]
 
   constructor(title = "Circuit Netlist") {
     this.title = title
@@ -21,6 +22,7 @@ export class SpiceNetlist {
     this.models = new Map()
     this.tranCommand = null
     this.printStatements = []
+    this.saveStatements = []
   }
 
   addComponent(component: SpiceComponent) {

--- a/lib/spice-utils/convertSpiceNetlistToString.ts
+++ b/lib/spice-utils/convertSpiceNetlistToString.ts
@@ -25,6 +25,10 @@ export const convertSpiceNetlistToString = (netlist: SpiceNetlist): string => {
     lines.push(...netlist.printStatements)
   }
 
+  if (netlist.saveStatements.length > 0) {
+    lines.push(...netlist.saveStatements)
+  }
+
   // Add control block if present
   if (netlist.controls.length > 0) {
     lines.push(".control")

--- a/tests/examples/buck-converter.test.tsx
+++ b/tests/examples/buck-converter.test.tsx
@@ -22,6 +22,7 @@ test(
       Vsimulation_voltage_source_0 VP_IN 0 DC 5
       Vsimulation_voltage_source_1 N1 0 PULSE(0 10 0 1n 1n 0.0005 0.001)
       .PRINT TRAN V(VP_IN) V(VP_OUT)
+      .SAVE V(VP_IN) V(VP_OUT)
       .tran 0.00001 0.05 UIC
       .END"
     `)

--- a/tests/examples/switch.test.tsx
+++ b/tests/examples/switch.test.tsx
@@ -21,6 +21,7 @@ test(
       RR_collector N1 VP_COLLECTOR 300
       Vsimulation_voltage_source_0 N1 0 DC 5
       .PRINT TRAN V(VP_BASE) V(VP_COLLECTOR)
+      .SAVE V(VP_BASE) V(VP_COLLECTOR)
       .tran 0.00005 0.004 UIC
       .END"
     `)

--- a/tests/unit/voltage-probe.test.ts
+++ b/tests/unit/voltage-probe.test.ts
@@ -83,6 +83,7 @@ test("voltage probe with signal_input_source_port_id creates .PRINT statement", 
   const spiceString = netlist.toSpiceString()
 
   expect(spiceString).toContain(`.PRINT TRAN V(VOUT)`)
+  expect(spiceString).toContain(`.SAVE V(VOUT)`)
   expect(spiceString).toContain(`RR1 N1 VOUT 1K`)
   expect(spiceString).toContain(`RR2 VOUT N2 1K`)
 })
@@ -102,6 +103,7 @@ test("voltage probe with signal_input_source_net_id creates .PRINT statement", (
   const spiceString = netlist.toSpiceString()
 
   expect(spiceString).toContain(`.PRINT TRAN V(VOUT)`)
+  expect(spiceString).toContain(`.SAVE V(VOUT)`)
   expect(spiceString).toContain(`RR1 N1 VOUT 1K`)
   expect(spiceString).toContain(`RR2 VOUT N2 1K`)
 })
@@ -121,6 +123,7 @@ test("voltage probe without transient analysis does not create .PRINT statement"
   const spiceString = netlist.toSpiceString()
 
   expect(spiceString).not.toContain(".PRINT")
+  expect(spiceString).not.toContain(".SAVE")
   expect(spiceString).toContain("RR1 N1 VOUT 1K")
 })
 
@@ -159,6 +162,7 @@ test("voltage probe on ground node is ignored, but other probes are not", () => 
   // `R2_p2` is now connected to GND, so it's node 0 and should be ignored
   // `R1_p2` is a non-gnd node and should be printed.
   expect(spiceString).toContain(`.PRINT TRAN V(VOUT)`)
+  expect(spiceString).toContain(`.SAVE V(VOUT)`)
   expect(spiceString).not.toContain("V(0)")
   expect(spiceString).toContain("RR1 N1 VOUT 1K")
   expect(spiceString).toContain("RR2 VOUT 0 1K")
@@ -190,6 +194,7 @@ test("multiple voltage probes create single .PRINT statement", () => {
 
   // The order of probes in the .PRINT statement is not guaranteed
   expect(spiceString).toContain(".PRINT TRAN")
+  expect(spiceString).toContain(".SAVE")
   expect(spiceString).toContain("V(N1)")
   expect(spiceString).toContain("V(VOUT)")
 })
@@ -377,6 +382,7 @@ test("probes with N-style names don't conflict with auto-generated names", () =>
 
   // The order of probes in the .PRINT statement is not guaranteed
   expect(spiceString).toContain(".PRINT TRAN")
+  expect(spiceString).toContain(".SAVE")
   expect(spiceString).toContain("V(N1)")
   expect(spiceString).toContain("V(N2)")
   expect(spiceString).toContain("V(N4)")
@@ -402,6 +408,7 @@ test("differential voltage probe creates .PRINT statement", () => {
   expect(spiceString).toContain("RR1 N2 N1 1K")
   expect(spiceString).toContain("RR2 N1 N3 1K")
   expect(spiceString).toContain(".PRINT TRAN V(N2,N1)")
+  expect(spiceString).toContain(".SAVE V(N2,N1)")
 })
 
 test("differential voltage probe without a name creates .PRINT statement", () => {
@@ -425,4 +432,5 @@ test("differential voltage probe without a name creates .PRINT statement", () =>
   expect(spiceString).toContain("RR1 N2 N1 1K")
   expect(spiceString).toContain("RR2 N1 N3 1K")
   expect(spiceString).toContain(".PRINT TRAN V(N2,N1)")
+  expect(spiceString).toContain(".SAVE V(N2,N1)")
 })


### PR DESCRIPTION
to save memory by not getting every single output