### PR TITLE
Add SPICE options, pulse timing, and probe metadata

### DIFF
--- a/lib/processors/helpers.ts
+++ b/lib/processors/helpers.ts
@@ -92,3 +92,31 @@ export function formatNumberForSpice(value: number) {
 
   return Number(value.toPrecision(6)).toString()
 }
+
+export function formatSecondsForSpice(value: number) {
+  if (!Number.isFinite(value)) return `${value}`
+  if (value === 0) return "0"
+
+  const units = [
+    ["T", 1e12],
+    ["G", 1e9],
+    ["MEG", 1e6],
+    ["k", 1e3],
+    ["m", 1e-3],
+    ["u", 1e-6],
+    ["n", 1e-9],
+    ["p", 1e-12],
+  ] as const
+
+  for (const [suffix, multiplier] of units) {
+    const scaled = value / multiplier
+    if (Math.abs(scaled) >= 0.999999 && Math.abs(scaled) < 999.999999) {
+      const rounded = Number(scaled.toPrecision(6))
+      if (Math.abs(rounded * multiplier - value) <= Math.abs(value) * 1e-9) {
+        return `${rounded}${suffix}`
+      }
+    }
+  }
+
+  return formatNumberForSpice(value)
+}

--- a/lib/processors/process-simulation-experiment.ts
+++ b/lib/processors/process-simulation-experiment.ts
@@ -6,6 +6,16 @@ import type {
 import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
 import { formatNumberForSpice } from "./helpers"
 
+const spiceOptionOrder = ["method", "reltol", "abstol", "vntol"] as const
+
+interface ProbeVectorMapping {
+  simulation_voltage_probe_id: string
+  name?: string
+  spice_vector: string
+  source_node_name: string
+  reference_node_name?: string
+}
+
 export const processSimulationExperiment = (
   netlist: SpiceNetlist,
   simExperiment: SimulationExperiment,
@@ -15,9 +25,24 @@ export const processSimulationExperiment = (
 ) => {
   if (!simExperiment) return
 
+  const spiceOptions = simExperiment.spice_options
+  if (spiceOptions) {
+    const optionParts = spiceOptionOrder
+      .map((key) => {
+        const value = spiceOptions[key]
+        return value === undefined ? null : `${key}=${value}`
+      })
+      .filter((part): part is string => part !== null)
+
+    if (optionParts.length > 0) {
+      netlist.optionStatements.push(`.options ${optionParts.join(" ")}`)
+    }
+  }
+
   // Process simulation voltage probes
   if (simulationProbes.length > 0) {
     const nodesToProbe = new Set<string>()
+    const probeVectorMappings: ProbeVectorMapping[] = []
 
     const getPortIdFromNetId = (netId: string) => {
       const trace = sourceTraces.find((t) =>
@@ -50,14 +75,37 @@ export const processSimulationExperiment = (
       if (referencePortId) {
         const referenceNodeName = nodeMap.get(referencePortId)
         if (referenceNodeName && referenceNodeName !== "0") {
-          nodesToProbe.add(`V(${signalNodeName},${referenceNodeName})`)
+          const spiceVector = `V(${signalNodeName},${referenceNodeName})`
+          nodesToProbe.add(spiceVector)
+          probeVectorMappings.push({
+            simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
+            name: probe.name,
+            spice_vector: spiceVector,
+            source_node_name: signalNodeName,
+            reference_node_name: referenceNodeName,
+          })
         } else if (signalNodeName !== "0") {
-          nodesToProbe.add(`V(${signalNodeName})`)
+          const spiceVector = `V(${signalNodeName})`
+          nodesToProbe.add(spiceVector)
+          probeVectorMappings.push({
+            simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
+            name: probe.name,
+            spice_vector: spiceVector,
+            source_node_name: signalNodeName,
+            reference_node_name: referenceNodeName,
+          })
         }
       } else {
         // Single-ended probe
         if (signalNodeName !== "0") {
-          nodesToProbe.add(`V(${signalNodeName})`)
+          const spiceVector = `V(${signalNodeName})`
+          nodesToProbe.add(spiceVector)
+          probeVectorMappings.push({
+            simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
+            name: probe.name,
+            spice_vector: spiceVector,
+            source_node_name: signalNodeName,
+          })
         }
       }
     }
@@ -66,6 +114,11 @@ export const processSimulationExperiment = (
       nodesToProbe.size > 0 &&
       simExperiment.experiment_type?.includes("transient")
     ) {
+      for (const mapping of probeVectorMappings) {
+        netlist.metadataComments.push(
+          `* tscircuit_probe ${JSON.stringify(mapping)}`,
+        )
+      }
       const probeVectors = [...nodesToProbe].join(" ")
       netlist.printStatements.push(`.PRINT TRAN ${probeVectors}`)
       netlist.saveStatements.push(`.SAVE ${probeVectors}`)

--- a/lib/processors/process-simulation-voltage-sources.ts
+++ b/lib/processors/process-simulation-voltage-sources.ts
@@ -2,6 +2,7 @@ import type { AnyCircuitElement, SimulationVoltageSource } from "circuit-json"
 import { SpiceComponent } from "lib/spice-classes/SpiceComponent"
 import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
 import { VoltageSourceCommand } from "lib/spice-commands"
+import { formatSecondsForSpice } from "./helpers"
 
 export const processSimulationVoltageSources = (
   netlist: SpiceNetlist,
@@ -43,13 +44,30 @@ export const processSimulationVoltageSources = (
           const v_pulsed = simSource.voltage ?? 0
           const freq = simSource.frequency ?? 0
           const period_from_freq = freq === 0 ? Infinity : 1 / freq
-          const period = period_from_freq
+          const hasExplicitPeriod = simSource.period !== undefined
+          const hasExplicitPulseWidth = simSource.pulse_width !== undefined
+          const period = hasExplicitPeriod
+            ? simSource.period! / 1000
+            : period_from_freq
           const duty_cycle = simSource.duty_cycle ?? 0.5
           const pulse_width = period * duty_cycle
-          const delay = 0
-          const rise_time = "1n"
-          const fall_time = "1n"
-          value = `PULSE(${v_initial} ${v_pulsed} ${delay} ${rise_time} ${fall_time} ${pulse_width} ${period})`
+          const delay =
+            simSource.pulse_delay !== undefined
+              ? simSource.pulse_delay / 1000
+              : 0
+          const rise_time =
+            simSource.rise_time !== undefined
+              ? formatSecondsForSpice(simSource.rise_time / 1000)
+              : "1n"
+          const fall_time =
+            simSource.fall_time !== undefined
+              ? formatSecondsForSpice(simSource.fall_time / 1000)
+              : "1n"
+          const pulseWidthText = hasExplicitPulseWidth
+            ? formatSecondsForSpice(simSource.pulse_width! / 1000)
+            : formatSecondsForSpice(pulse_width)
+          const periodText = formatSecondsForSpice(period)
+          value = `PULSE(${v_initial} ${v_pulsed} ${formatSecondsForSpice(delay)} ${rise_time} ${fall_time} ${pulseWidthText} ${periodText})`
         } else if (simSource.voltage !== undefined) {
           value = `DC ${simSource.voltage}`
         }

--- a/lib/spice-classes/SpiceNetlist.ts
+++ b/lib/spice-classes/SpiceNetlist.ts
@@ -9,6 +9,8 @@ export class SpiceNetlist {
   controls: string[]
   subcircuits: SpiceSubcircuit[]
   models: Map<string, string>
+  optionStatements: string[]
+  metadataComments: string[]
   tranCommand: string | null
   printStatements: string[]
   saveStatements: string[]
@@ -20,6 +22,8 @@ export class SpiceNetlist {
     this.controls = []
     this.subcircuits = []
     this.models = new Map()
+    this.optionStatements = []
+    this.metadataComments = []
     this.tranCommand = null
     this.printStatements = []
     this.saveStatements = []

--- a/lib/spice-utils/convertSpiceNetlistToString.ts
+++ b/lib/spice-utils/convertSpiceNetlistToString.ts
@@ -16,6 +16,14 @@ export const convertSpiceNetlistToString = (netlist: SpiceNetlist): string => {
     lines.push(component.toSpiceString())
   }
 
+  if (netlist.optionStatements.length > 0) {
+    lines.push(...netlist.optionStatements)
+  }
+
+  if (netlist.metadataComments.length > 0) {
+    lines.push(...netlist.metadataComments)
+  }
+
   // Add subcircuit definitions
   for (const subcircuit of netlist.subcircuits) {
     lines.push(subcircuit.toSpiceString())

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "@tscircuit/circuit-json-util": "^0.0.72",
     "@types/bun": "^1.2.15",
     "bun-match-svg": "^0.0.13",
-    "circuit-json": "^0.0.430",
+    "circuit-json": "^0.0.435",
+    "format-si-unit": "^0.0.7",
     "eecircuit-engine": "^1.5.2",
     "tscircuit": "^0.0.936",
     "tsup": "^8.4.0"

--- a/tests/examples/boost-converter.test.tsx
+++ b/tests/examples/boost-converter.test.tsx
@@ -24,7 +24,7 @@ test(
       RR1 N3 0 1K
       MM1 N2 N4 0 0 NMOS_ENHANCEMENT
       Vsimulation_voltage_source_0 N1 0 DC 5
-      Vsimulation_voltage_source_1 N4 0 PULSE(0 10 0 1n 1n 0.00068 0.001)
+      Vsimulation_voltage_source_1 N4 0 PULSE(0 10 0 1n 1n 680u 1m)
       .END"
     `)
 

--- a/tests/examples/buck-converter.test.tsx
+++ b/tests/examples/buck-converter.test.tsx
@@ -20,7 +20,9 @@ test(
       CC1 VP_OUT 0 10U
       RR1 VP_OUT 0 1K
       Vsimulation_voltage_source_0 VP_IN 0 DC 5
-      Vsimulation_voltage_source_1 N1 0 PULSE(0 10 0 1n 1n 0.0005 0.001)
+      Vsimulation_voltage_source_1 N1 0 PULSE(0 10 0 1n 1n 500u 1m)
+      * tscircuit_probe {"simulation_voltage_probe_id":"simulation_voltage_probe_0","name":"VP_IN","spice_vector":"V(VP_IN)","source_node_name":"VP_IN"}
+      * tscircuit_probe {"simulation_voltage_probe_id":"simulation_voltage_probe_1","name":"VP_OUT","spice_vector":"V(VP_OUT)","source_node_name":"VP_OUT"}
       .PRINT TRAN V(VP_IN) V(VP_OUT)
       .SAVE V(VP_IN) V(VP_OUT)
       .tran 0.00001 0.05 UIC

--- a/tests/examples/switch.test.tsx
+++ b/tests/examples/switch.test.tsx
@@ -20,6 +20,8 @@ test(
       QQ1 VP_COLLECTOR N2 0 NPN
       RR_collector N1 VP_COLLECTOR 300
       Vsimulation_voltage_source_0 N1 0 DC 5
+      * tscircuit_probe {"simulation_voltage_probe_id":"simulation_voltage_probe_0","name":"VP_BASE","spice_vector":"V(VP_BASE)","source_node_name":"VP_BASE"}
+      * tscircuit_probe {"simulation_voltage_probe_id":"simulation_voltage_probe_1","name":"VP_COLLECTOR","spice_vector":"V(VP_COLLECTOR)","source_node_name":"VP_COLLECTOR"}
       .PRINT TRAN V(VP_BASE) V(VP_COLLECTOR)
       .SAVE V(VP_BASE) V(VP_COLLECTOR)
       .tran 0.00005 0.004 UIC

--- a/tests/unit/circuit-json-conversion.test.tsx
+++ b/tests/unit/circuit-json-conversion.test.tsx
@@ -54,6 +54,131 @@ test("circuit with simulation voltage source", async () => {
   `)
 })
 
+test("square simulation voltage source uses explicit pulse timing controls", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_net",
+      source_net_id: "net_en",
+      name: "EN",
+      member_source_group_ids: [],
+    } as AnyCircuitElement,
+    {
+      type: "source_net",
+      source_net_id: "net_gnd",
+      name: "GND",
+      member_source_group_ids: [],
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "V_EN_pos",
+      name: "pos",
+      source_component_id: "V_EN",
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "V_EN_neg",
+      name: "neg",
+      source_component_id: "V_EN",
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "trace_en",
+      connected_source_port_ids: ["V_EN_pos"],
+      connected_source_net_ids: ["net_en"],
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "trace_gnd",
+      connected_source_port_ids: ["V_EN_neg"],
+      connected_source_net_ids: ["net_gnd"],
+    } as AnyCircuitElement,
+    {
+      type: "simulation_voltage_source",
+      simulation_voltage_source_id: "simulation_voltage_source_en",
+      is_dc_source: false,
+      terminal1_source_port_id: "V_EN_pos",
+      terminal2_source_port_id: "V_EN_neg",
+      voltage: 4.2,
+      wave_shape: "square",
+      pulse_delay: 0.001,
+      rise_time: 0.000001,
+      fall_time: 0.000001,
+      pulse_width: 2,
+      period: 4,
+    } as AnyCircuitElement,
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+
+  expect(netlist.toSpiceString()).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    Vsimulation_voltage_source_en N1 0 PULSE(0 4.2 1u 1n 1n 2m 4m)
+    .END"
+  `)
+})
+
+test("square simulation voltage source preserves explicit zero pulse timing controls", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "source_net",
+      source_net_id: "net_en",
+      name: "EN",
+      member_source_group_ids: [],
+    } as AnyCircuitElement,
+    {
+      type: "source_net",
+      source_net_id: "net_gnd",
+      name: "GND",
+      member_source_group_ids: [],
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "V_EN_pos",
+      name: "pos",
+      source_component_id: "V_EN",
+    } as AnyCircuitElement,
+    {
+      type: "source_port",
+      source_port_id: "V_EN_neg",
+      name: "neg",
+      source_component_id: "V_EN",
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "trace_en",
+      connected_source_port_ids: ["V_EN_pos"],
+      connected_source_net_ids: ["net_en"],
+    } as AnyCircuitElement,
+    {
+      type: "source_trace",
+      source_trace_id: "trace_gnd",
+      connected_source_port_ids: ["V_EN_neg"],
+      connected_source_net_ids: ["net_gnd"],
+    } as AnyCircuitElement,
+    {
+      type: "simulation_voltage_source",
+      simulation_voltage_source_id: "simulation_voltage_source_en",
+      is_dc_source: false,
+      terminal1_source_port_id: "V_EN_pos",
+      terminal2_source_port_id: "V_EN_neg",
+      voltage: 4.2,
+      wave_shape: "square",
+      frequency: 1000,
+      pulse_delay: 0,
+      rise_time: 0,
+      fall_time: 0,
+    } as AnyCircuitElement,
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+
+  expect(netlist.toSpiceString()).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    Vsimulation_voltage_source_en N1 0 PULSE(0 4.2 0 0 0 500u 1m)
+    .END"
+  `)
+})
+
 test("simple led emits diode element and LED model", () => {
   const circuitJson: AnyCircuitElement[] = [
     {

--- a/tests/unit/helpers.test.ts
+++ b/tests/unit/helpers.test.ts
@@ -1,0 +1,15 @@
+import { expect, test } from "bun:test"
+import { formatSecondsForSpice } from "lib/processors/helpers"
+
+test("formatSecondsForSpice formats common transient timing values", () => {
+  expect(formatSecondsForSpice(0)).toBe("0")
+  expect(formatSecondsForSpice(1e-9)).toBe("1n")
+  expect(formatSecondsForSpice(1e-6)).toBe("1u")
+  expect(formatSecondsForSpice(0.0005)).toBe("500u")
+  expect(formatSecondsForSpice(0.001)).toBe("1m")
+  expect(formatSecondsForSpice(0.002)).toBe("2m")
+})
+
+test("formatSecondsForSpice formats fractional engineering values when exact", () => {
+  expect(formatSecondsForSpice(0.00071556)).toBe("715.56u")
+})

--- a/tests/unit/transient-simulation.test.ts
+++ b/tests/unit/transient-simulation.test.ts
@@ -150,3 +150,36 @@ test("circuit with simulation experiment and 0 start time adds .tran command", (
     .END"
   `)
 })
+
+test("circuit with simulation experiment adds spice options before transient command", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: "se1",
+      name: "TPS63802 Figure 10-17 transient",
+      experiment_type: "spice_transient_analysis",
+      time_per_step: 0.000005,
+      start_time_ms: 0.69758,
+      end_time_ms: 0.71556,
+      spice_options: {
+        method: "gear",
+        reltol: 0.01,
+        abstol: "1n",
+        vntol: "1u",
+      },
+    } as AnyCircuitElement,
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).toContain(
+    ".options method=gear reltol=0.01 abstol=1n vntol=1u\n.tran 5e-9 0.00071556 0.00069758 UIC",
+  )
+  expect(spiceString).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    .options method=gear reltol=0.01 abstol=1n vntol=1u
+    .tran 5e-9 0.00071556 0.00069758 UIC
+    .END"
+  `)
+})

--- a/tests/unit/voltage-probe.test.ts
+++ b/tests/unit/voltage-probe.test.ts
@@ -84,6 +84,9 @@ test("voltage probe with signal_input_source_port_id creates .PRINT statement", 
 
   expect(spiceString).toContain(`.PRINT TRAN V(VOUT)`)
   expect(spiceString).toContain(`.SAVE V(VOUT)`)
+  expect(spiceString).toContain(
+    `* tscircuit_probe {"simulation_voltage_probe_id":"probe1","name":"VOUT","spice_vector":"V(VOUT)","source_node_name":"VOUT"}`,
+  )
   expect(spiceString).toContain(`RR1 N1 VOUT 1K`)
   expect(spiceString).toContain(`RR2 VOUT N2 1K`)
 })
@@ -407,6 +410,9 @@ test("differential voltage probe creates .PRINT statement", () => {
 
   expect(spiceString).toContain("RR1 N2 N1 1K")
   expect(spiceString).toContain("RR2 N1 N3 1K")
+  expect(spiceString).toContain(
+    `* tscircuit_probe {"simulation_voltage_probe_id":"probe_diff","name":"VR1","spice_vector":"V(N2,N1)","source_node_name":"N2","reference_node_name":"N1"}`,
+  )
   expect(spiceString).toContain(".PRINT TRAN V(N2,N1)")
   expect(spiceString).toContain(".SAVE V(N2,N1)")
 })


### PR DESCRIPTION
  Adds support for simulation_experiment.spice_options, emits voltage-source PULSE delay/rise/fall/
  width/period controls, and formats transient timing values with SPICE suffixes. Also emits
  tscircuit_probe metadata comments that map voltage probes to SPICE vectors so downstream
  simulation graph rendering can recover probe identity.