### PR TITLE
Introduce SPICE Current Probe Instrumentation with Automatic Sense Sources and Transient Waveform Capture

### DIFF
--- a/lib/circuitJsonToSpice.ts
+++ b/lib/circuitJsonToSpice.ts
@@ -2,6 +2,7 @@ import { SpiceNetlist } from "./spice-classes/SpiceNetlist"
 import { SpiceComponent } from "./spice-classes/SpiceComponent"
 import type {
   AnyCircuitElement,
+  SimulationCurrentProbe,
   SimulationOpAmp,
   SimulationSpiceSubcircuit,
   SimulationSwitch,
@@ -37,6 +38,9 @@ export function circuitJsonToSpice(
   const simulationProbes = circuitJson.filter(
     (elm) => elm.type === "simulation_voltage_probe",
   ) as SimulationVoltageProbe[]
+  const simulationCurrentProbes = circuitJson.filter(
+    (elm) => elm.type === "simulation_current_probe",
+  ) as SimulationCurrentProbe[]
   const simulationSwitches = circuitJson
     .filter(
       (element) => (element as { type?: string }).type === "simulation_switch",
@@ -309,6 +313,7 @@ export function circuitJsonToSpice(
       netlist,
       simulationExperiment,
       simulationProbes,
+      simulationCurrentProbes,
       sourceTraces,
       nodeMap,
     )

--- a/lib/processors/process-simulation-experiment.ts
+++ b/lib/processors/process-simulation-experiment.ts
@@ -1,14 +1,17 @@
 import type {
+  SimulationCurrentProbe,
   SimulationExperiment,
   SimulationVoltageProbe,
   SourceTrace,
 } from "circuit-json"
+import { SpiceComponent } from "lib/spice-classes/SpiceComponent"
 import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
-import { formatNumberForSpice } from "./helpers"
+import { VoltageSourceCommand } from "lib/spice-commands"
+import { formatNumberForSpice, sanitizeIdentifier } from "./helpers"
 
 const spiceOptionOrder = ["method", "reltol", "abstol", "vntol"] as const
 
-interface ProbeVectorMapping {
+interface VoltageProbeVectorMapping {
   simulation_voltage_probe_id: string
   name?: string
   spice_vector: string
@@ -16,14 +19,64 @@ interface ProbeVectorMapping {
   reference_node_name?: string
 }
 
+interface CurrentProbeVectorMapping {
+  simulation_current_probe_id: string
+  name?: string
+  spice_vector: string
+  sense_voltage_source_name: string
+  positive_node_name: string
+  negative_node_name: string
+}
+
+const getPortIdFromNetId = (sourceTraces: SourceTrace[], netId: string) => {
+  const trace = sourceTraces.find((t) =>
+    t.connected_source_net_ids.includes(netId),
+  )
+  return trace?.connected_source_port_ids[0]
+}
+
+const resolveNodeNameFromSourcePortOrNet = ({
+  sourcePortId,
+  sourceNetId,
+  sourceTraces,
+  nodeMap,
+}: {
+  sourcePortId?: string
+  sourceNetId?: string
+  sourceTraces: SourceTrace[]
+  nodeMap: Map<string, string>
+}) => {
+  if (sourcePortId) {
+    return nodeMap.get(sourcePortId)
+  }
+
+  if (!sourceNetId) return undefined
+
+  const sourcePortIdFromNet = getPortIdFromNetId(sourceTraces, sourceNetId)
+  if (!sourcePortIdFromNet) return undefined
+
+  return nodeMap.get(sourcePortIdFromNet)
+}
+
+const getSenseVoltageSourceName = (probe: SimulationCurrentProbe) =>
+  sanitizeIdentifier(
+    `sense_${probe.simulation_current_probe_id}`,
+    "sense_current_probe",
+  )
+
 export const processSimulationExperiment = (
   netlist: SpiceNetlist,
   simExperiment: SimulationExperiment,
   simulationProbes: SimulationVoltageProbe[],
+  simulationCurrentProbes: SimulationCurrentProbe[],
   sourceTraces: SourceTrace[],
   nodeMap: Map<string, string>,
 ) => {
   if (!simExperiment) return
+
+  const isTransientExperiment =
+    simExperiment.experiment_type?.includes("transient") ?? false
+  const transientProbeVectors = new Set<string>()
 
   const spiceOptions = simExperiment.spice_options
   if (spiceOptions) {
@@ -41,42 +94,31 @@ export const processSimulationExperiment = (
 
   // Process simulation voltage probes
   if (simulationProbes.length > 0) {
-    const nodesToProbe = new Set<string>()
-    const probeVectorMappings: ProbeVectorMapping[] = []
-
-    const getPortIdFromNetId = (netId: string) => {
-      const trace = sourceTraces.find((t) =>
-        t.connected_source_net_ids.includes(netId),
-      )
-      return trace?.connected_source_port_ids[0]
-    }
+    const probeVectorMappings: VoltageProbeVectorMapping[] = []
 
     for (const probe of simulationProbes) {
-      let signalPortId = probe.signal_input_source_port_id
-      if (!signalPortId) {
-        const signalNetId = probe.signal_input_source_net_id
-        if (signalNetId) {
-          signalPortId = getPortIdFromNetId(signalNetId)
-        }
-      }
-
-      if (!signalPortId) continue
-
-      const signalNodeName = nodeMap.get(signalPortId)
+      const signalNodeName = resolveNodeNameFromSourcePortOrNet({
+        sourcePortId: probe.signal_input_source_port_id,
+        sourceNetId: probe.signal_input_source_net_id,
+        sourceTraces,
+        nodeMap,
+      })
       if (!signalNodeName) continue
 
-      let referencePortId = probe.reference_input_source_port_id
-      if (!referencePortId && probe.reference_input_source_net_id) {
-        referencePortId = getPortIdFromNetId(
-          probe.reference_input_source_net_id,
-        )
-      }
+      const hasReference =
+        probe.reference_input_source_port_id ||
+        probe.reference_input_source_net_id
 
-      if (referencePortId) {
-        const referenceNodeName = nodeMap.get(referencePortId)
+      if (hasReference) {
+        const referenceNodeName = resolveNodeNameFromSourcePortOrNet({
+          sourcePortId: probe.reference_input_source_port_id,
+          sourceNetId: probe.reference_input_source_net_id,
+          sourceTraces,
+          nodeMap,
+        })
         if (referenceNodeName && referenceNodeName !== "0") {
           const spiceVector = `V(${signalNodeName},${referenceNodeName})`
-          nodesToProbe.add(spiceVector)
+          transientProbeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -86,7 +128,7 @@ export const processSimulationExperiment = (
           })
         } else if (signalNodeName !== "0") {
           const spiceVector = `V(${signalNodeName})`
-          nodesToProbe.add(spiceVector)
+          transientProbeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -99,7 +141,7 @@ export const processSimulationExperiment = (
         // Single-ended probe
         if (signalNodeName !== "0") {
           const spiceVector = `V(${signalNodeName})`
-          nodesToProbe.add(spiceVector)
+          transientProbeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -110,19 +152,84 @@ export const processSimulationExperiment = (
       }
     }
 
-    if (
-      nodesToProbe.size > 0 &&
-      simExperiment.experiment_type?.includes("transient")
-    ) {
+    if (probeVectorMappings.length > 0 && isTransientExperiment) {
       for (const mapping of probeVectorMappings) {
         netlist.metadataComments.push(
           `* tscircuit_probe ${JSON.stringify(mapping)}`,
         )
       }
-      const probeVectors = [...nodesToProbe].join(" ")
-      netlist.printStatements.push(`.PRINT TRAN ${probeVectors}`)
-      netlist.saveStatements.push(`.SAVE ${probeVectors}`)
     }
+  }
+
+  // Process simulation current probes
+  if (simulationCurrentProbes.length > 0 && isTransientExperiment) {
+    const senseVoltageSourceNames = new Set<string>()
+    const currentProbeVectorMappings: CurrentProbeVectorMapping[] = []
+
+    for (const probe of simulationCurrentProbes) {
+      const positiveNodeName = resolveNodeNameFromSourcePortOrNet({
+        sourcePortId: probe.positive_source_port_id,
+        sourceNetId: probe.positive_source_net_id,
+        sourceTraces,
+        nodeMap,
+      })
+      const negativeNodeName = resolveNodeNameFromSourcePortOrNet({
+        sourcePortId: probe.negative_source_port_id,
+        sourceNetId: probe.negative_source_net_id,
+        sourceTraces,
+        nodeMap,
+      })
+
+      if (!positiveNodeName || !negativeNodeName) continue
+
+      const senseVoltageSourceBaseName = getSenseVoltageSourceName(probe)
+      let senseVoltageSourceName = senseVoltageSourceBaseName
+      let duplicateIndex = 2
+      while (senseVoltageSourceNames.has(senseVoltageSourceName)) {
+        senseVoltageSourceName = `${senseVoltageSourceBaseName}_${duplicateIndex++}`
+      }
+      senseVoltageSourceNames.add(senseVoltageSourceName)
+
+      const spiceSenseVoltageSourceName = `V${senseVoltageSourceName}`
+      const spiceVector = `I(${spiceSenseVoltageSourceName})`
+      const voltageSourceCmd = new VoltageSourceCommand({
+        name: senseVoltageSourceName,
+        positiveNode: positiveNodeName,
+        negativeNode: negativeNodeName,
+        value: "DC 0",
+      })
+
+      netlist.addComponent(
+        new SpiceComponent(senseVoltageSourceName, voltageSourceCmd, [
+          positiveNodeName,
+          negativeNodeName,
+        ]),
+      )
+
+      transientProbeVectors.add(spiceVector)
+      currentProbeVectorMappings.push({
+        simulation_current_probe_id: probe.simulation_current_probe_id,
+        name: probe.name,
+        spice_vector: spiceVector,
+        sense_voltage_source_name: spiceSenseVoltageSourceName,
+        positive_node_name: positiveNodeName,
+        negative_node_name: negativeNodeName,
+      })
+    }
+
+    if (currentProbeVectorMappings.length > 0) {
+      for (const mapping of currentProbeVectorMappings) {
+        netlist.metadataComments.push(
+          `* tscircuit_current_probe ${JSON.stringify(mapping)}`,
+        )
+      }
+    }
+  }
+
+  if (transientProbeVectors.size > 0 && isTransientExperiment) {
+    const probeVectors = [...transientProbeVectors].join(" ")
+    netlist.printStatements.push(`.PRINT TRAN ${probeVectors}`)
+    netlist.saveStatements.push(`.SAVE ${probeVectors}`)
   }
 
   const timePerStep = simExperiment.time_per_step

--- a/lib/processors/process-simulation-experiment.ts
+++ b/lib/processors/process-simulation-experiment.ts
@@ -161,8 +161,9 @@ export const processSimulationExperiment = (
     }
   }
 
-  // Process simulation current probes
-  if (simulationCurrentProbes.length > 0 && isTransientExperiment) {
+  // Current probes are inline ammeter elements, so the 0V sense source is part
+  // of the simulated topology even when the experiment does not print current.
+  if (simulationCurrentProbes.length > 0) {
     const senseVoltageSourceNames = new Set<string>()
     const currentProbeVectorMappings: CurrentProbeVectorMapping[] = []
 
@@ -206,7 +207,9 @@ export const processSimulationExperiment = (
         ]),
       )
 
-      transientProbeVectors.add(spiceVector)
+      if (isTransientExperiment) {
+        transientProbeVectors.add(spiceVector)
+      }
       currentProbeVectorMappings.push({
         simulation_current_probe_id: probe.simulation_current_probe_id,
         name: probe.name,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tscircuit/circuit-json-util": "^0.0.72",
     "@types/bun": "^1.2.15",
     "bun-match-svg": "^0.0.13",
-    "circuit-json": "^0.0.435",
+    "circuit-json": "^0.0.436",
     "format-si-unit": "^0.0.7",
     "eecircuit-engine": "^1.5.2",
     "tscircuit": "^0.0.936",

--- a/tests/unit/current-probe.test.ts
+++ b/tests/unit/current-probe.test.ts
@@ -31,6 +31,8 @@ const baseCircuit: AnyCircuitElement[] = [
     source_component_id: "AM1",
     name: "AM1",
   } as unknown as AnyCircuitElement,
+  // Test-only inline ammeter placeholder; the simulation_current_probe record
+  // below supplies the generated 0V SPICE sense source for this branch.
   {
     type: "source_port",
     source_port_id: "AM1_p1",
@@ -100,7 +102,7 @@ const baseCircuit: AnyCircuitElement[] = [
   },
 ]
 
-test("port-based current probe creates a series 0V sense source and current output", () => {
+test("port-based inline current probe creates a series 0V sense source and current output", () => {
   const circuitJson: AnyCircuitElement[] = [
     ...baseCircuit,
     currentProbe({
@@ -161,7 +163,7 @@ test("net-based current probe resolves source net ids to node names", () => {
   )
 })
 
-test("current probe output is transient-only", () => {
+test("inline current probe sense source remains in non-transient netlists without transient output", () => {
   const circuitJson: AnyCircuitElement[] = [
     ...baseCircuit.filter(
       (element) => element.type !== "simulation_experiment",
@@ -183,10 +185,9 @@ test("current probe output is transient-only", () => {
   const netlist = circuitJsonToSpice(circuitJson)
   const spiceString = netlist.toSpiceString()
 
-  expect(spiceString).not.toContain("Vsense_cp_dc")
-  expect(spiceString).not.toContain(".PRINT")
+  expect(spiceString).toContain("Vsense_cp_dc N1 N2 DC 0")
+  expect(spiceString).not.toContain(".PRINT TRAN")
   expect(spiceString).not.toContain(".SAVE")
-  expect(spiceString).not.toContain("I(Vsense_cp_dc)")
 })
 
 test("multiple current probes share one .PRINT and one .SAVE current output", () => {

--- a/tests/unit/current-probe.test.ts
+++ b/tests/unit/current-probe.test.ts
@@ -1,0 +1,247 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, SimulationCurrentProbe } from "circuit-json"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+
+const currentProbe = (probe: SimulationCurrentProbe): AnyCircuitElement => probe
+
+const baseCircuit: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "R1",
+    name: "R1",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  },
+  {
+    type: "source_port",
+    source_port_id: "R1_p1",
+    source_component_id: "R1",
+    name: "p1",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "R1_p2",
+    source_component_id: "R1",
+    name: "p2",
+    pin_number: 2,
+  },
+  {
+    type: "source_component",
+    source_component_id: "AM1",
+    name: "AM1",
+  } as unknown as AnyCircuitElement,
+  {
+    type: "source_port",
+    source_port_id: "AM1_p1",
+    source_component_id: "AM1",
+    name: "p1",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "AM1_p2",
+    source_component_id: "AM1",
+    name: "p2",
+    pin_number: 2,
+  },
+  {
+    type: "source_component",
+    source_component_id: "R2",
+    name: "R2",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  },
+  {
+    type: "source_port",
+    source_port_id: "R2_p1",
+    source_component_id: "R2",
+    name: "p1",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "R2_p2",
+    source_component_id: "R2",
+    name: "p2",
+    pin_number: 2,
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "t_probe_pos",
+    connected_source_port_ids: ["R1_p2", "AM1_p1"],
+    connected_source_net_ids: ["net_probe_pos"],
+  },
+  {
+    type: "source_net",
+    source_net_id: "net_probe_pos",
+    name: "PROBE_POS",
+    member_source_group_ids: [],
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "t_probe_neg",
+    connected_source_port_ids: ["AM1_p2", "R2_p1"],
+    connected_source_net_ids: ["net_probe_neg"],
+  },
+  {
+    type: "source_net",
+    source_net_id: "net_probe_neg",
+    name: "PROBE_NEG",
+    member_source_group_ids: [],
+  },
+  {
+    type: "simulation_experiment",
+    simulation_experiment_id: "se1",
+    name: "Test Transient Analysis",
+    experiment_type: "spice_transient_analysis" as const,
+    time_per_step: 1,
+    end_time_ms: 100,
+  },
+]
+
+test("port-based current probe creates a series 0V sense source and current output", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    ...baseCircuit,
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp1",
+      name: "IAM1",
+      positive_source_port_id: "AM1_p1",
+      negative_source_port_id: "AM1_p2",
+    }),
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).toContain("RR1 N3 N1 1K")
+  expect(spiceString).toContain("Vsense_cp1 N1 N2 DC 0")
+  expect(spiceString).toContain("RR2 N2 N4 1K")
+  expect(spiceString).toContain(".PRINT TRAN I(Vsense_cp1)")
+  expect(spiceString).toContain(".SAVE I(Vsense_cp1)")
+  expect(spiceString).toContain(
+    `* tscircuit_current_probe {"simulation_current_probe_id":"cp1","name":"IAM1","spice_vector":"I(Vsense_cp1)","sense_voltage_source_name":"Vsense_cp1","positive_node_name":"N1","negative_node_name":"N2"}`,
+  )
+})
+
+test("net-based current probe resolves source net ids to node names", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    ...baseCircuit,
+    {
+      type: "source_net",
+      source_net_id: "gnd_net",
+      name: "gnd",
+      member_source_group_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "t_gnd",
+      connected_source_port_ids: ["R2_p2"],
+      connected_source_net_ids: ["gnd_net"],
+    },
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp_net",
+      name: "I_NET",
+      positive_source_net_id: "net_probe_pos",
+      negative_source_net_id: "net_probe_neg",
+    }),
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).toContain("RR2 N2 0 1K")
+  expect(spiceString).toContain("Vsense_cp_net N1 N2 DC 0")
+  expect(spiceString).toContain(".PRINT TRAN I(Vsense_cp_net)")
+  expect(spiceString).toContain(".SAVE I(Vsense_cp_net)")
+  expect(spiceString).toContain(
+    `* tscircuit_current_probe {"simulation_current_probe_id":"cp_net","name":"I_NET","spice_vector":"I(Vsense_cp_net)","sense_voltage_source_name":"Vsense_cp_net","positive_node_name":"N1","negative_node_name":"N2"}`,
+  )
+})
+
+test("current probe output is transient-only", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    ...baseCircuit.filter(
+      (element) => element.type !== "simulation_experiment",
+    ),
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: "se_dc",
+      name: "Test DC Operating Point",
+      experiment_type: "spice_dc_operating_point" as const,
+    },
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp_dc",
+      positive_source_port_id: "AM1_p1",
+      negative_source_port_id: "AM1_p2",
+    }),
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).not.toContain("Vsense_cp_dc")
+  expect(spiceString).not.toContain(".PRINT")
+  expect(spiceString).not.toContain(".SAVE")
+  expect(spiceString).not.toContain("I(Vsense_cp_dc)")
+})
+
+test("multiple current probes share one .PRINT and one .SAVE current output", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    ...baseCircuit,
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp_r1",
+      positive_source_port_id: "AM1_p1",
+      negative_source_port_id: "AM1_p2",
+    }),
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp_r2",
+      positive_source_port_id: "R1_p1",
+      negative_source_port_id: "R2_p2",
+    }),
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+
+  expect(spiceString).toContain("Vsense_cp_r1 N1 N2 DC 0")
+  expect(spiceString).toContain("Vsense_cp_r2 N3 N4 DC 0")
+  expect(spiceString).toContain(".PRINT TRAN I(Vsense_cp_r1) I(Vsense_cp_r2)")
+  expect(spiceString).toContain(".SAVE I(Vsense_cp_r1) I(Vsense_cp_r2)")
+})
+
+test("current and voltage probes emit one merged .PRINT and .SAVE", () => {
+  const circuitJson: AnyCircuitElement[] = [
+    ...baseCircuit,
+    {
+      type: "simulation_voltage_probe",
+      simulation_voltage_probe_id: "vp1",
+      name: "VPROBE_POS",
+      signal_input_source_port_id: "AM1_p1",
+    },
+    currentProbe({
+      type: "simulation_current_probe",
+      simulation_current_probe_id: "cp1",
+      name: "IAM1",
+      positive_source_port_id: "AM1_p1",
+      negative_source_port_id: "AM1_p2",
+    }),
+  ]
+
+  const netlist = circuitJsonToSpice(circuitJson)
+  const spiceString = netlist.toSpiceString()
+  const printStatements = spiceString
+    .split("\n")
+    .filter((line) => line.startsWith(".PRINT TRAN"))
+  const saveStatements = spiceString
+    .split("\n")
+    .filter((line) => line.startsWith(".SAVE"))
+
+  expect(printStatements).toEqual([".PRINT TRAN V(VPROBE_POS) I(Vsense_cp1)"])
+  expect(saveStatements).toEqual([".SAVE V(VPROBE_POS) I(Vsense_cp1)"])
+})


### PR DESCRIPTION

Adds end-to-end SPICE netlist support for simulation current probes by automatically instrumenting circuits with zero-volt sense sources and exporting current waveforms during transient analysis.

This PR includes:

* Current probe processing in SPICE netlist generation
* Automatic insertion of 0V sense voltage sources for current measurement
* Support for both port-based and net-based current probes
* Node resolution from source ports and source nets
* Automatic `.PRINT TRAN` and `.SAVE` generation for current waveforms
* Unified transient output handling for voltage and current probes
* Probe metadata emission for downstream waveform mapping
* Collision-safe sense source naming
* Support for multiple simultaneous current probes
* Comprehensive transient simulation regression coverage

This establishes the infrastructure required to measure branch current in generated SPICE simulations and enables transient current waveform visualization alongside existing voltage probe support. 
