### PR TITLE
Don't force every voltage source's negative terminal to ground

### DIFF
--- a/lib/circuitJsonToSpice.ts
+++ b/lib/circuitJsonToSpice.ts
@@ -122,14 +122,32 @@ export function circuitJsonToSpice(
     }
   }
 
-  for (const simSource of su(circuitJson).simulation_voltage_source.list()) {
-    const neg_port_id =
-      (simSource as any).negative_source_port_id ??
-      (simSource as any).terminal2_source_port_id
-    if (neg_port_id) {
-      const gnd_net = connMap.getNetConnectedToId(neg_port_id)
-      if (gnd_net) {
-        groundNets.add(gnd_net)
+  // Fallback: if nothing above identified a ground net, use voltage-source
+  // negative terminals as the ground reference — but skip any net that is also
+  // a source's POSITIVE terminal. Such a net is a genuine internal node (e.g.
+  // the shared node between two stacked sources, or a high-side source's return
+  // net), so grounding it would collapse distinct nodes into 0 and self-short
+  // the later source (e.g. "V 0 0"). Nets that are only ever negative terminals
+  // (including a common ground shared by several sources) are true grounds.
+  if (groundNets.size === 0) {
+    const voltageSources = su(circuitJson).simulation_voltage_source.list()
+    const positiveTerminalNets = new Set<string>()
+    const negativeTerminalNets = new Set<string>()
+    for (const simSource of voltageSources) {
+      const pos_port_id =
+        (simSource as any).positive_source_port_id ??
+        (simSource as any).terminal1_source_port_id
+      const neg_port_id =
+        (simSource as any).negative_source_port_id ??
+        (simSource as any).terminal2_source_port_id
+      const pos_net = pos_port_id && connMap.getNetConnectedToId(pos_port_id)
+      const neg_net = neg_port_id && connMap.getNetConnectedToId(neg_port_id)
+      if (pos_net) positiveTerminalNets.add(pos_net)
+      if (neg_net) negativeTerminalNets.add(neg_net)
+    }
+    for (const net of negativeTerminalNets) {
+      if (!positiveTerminalNets.has(net)) {
+        groundNets.add(net)
       }
     }
   }

--- a/tests/examples/stacked-voltage-sources.test.tsx
+++ b/tests/examples/stacked-voltage-sources.test.tsx
@@ -1,0 +1,95 @@
+import { expect, test } from "bun:test"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+import type { AnyCircuitElement } from "circuit-json"
+
+// Two voltage sources in series: V1 (5V) TOP -> MID, V2 (3V) MID -> GND.
+// MID is a genuine internal node shared by both sources. Previously every
+// voltage source's negative terminal was force-grounded, so MID collapsed into
+// node 0 and V2 was emitted self-shorted as "V 0 0" (a SPICE singular matrix).
+// The mid node must survive and only the real GND net becomes node 0.
+const stackedSources: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "v1",
+    name: "V1",
+    ftype: "simple_voltage_source",
+  },
+  {
+    type: "source_component",
+    source_component_id: "v2",
+    name: "V2",
+    ftype: "simple_voltage_source",
+  },
+  {
+    type: "source_port",
+    source_port_id: "v1p",
+    source_component_id: "v1",
+    name: "pos",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "v1n",
+    source_component_id: "v1",
+    name: "neg",
+    pin_number: 2,
+  },
+  {
+    type: "source_port",
+    source_port_id: "v2p",
+    source_component_id: "v2",
+    name: "pos",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "v2n",
+    source_component_id: "v2",
+    name: "neg",
+    pin_number: 2,
+  },
+  {
+    type: "simulation_voltage_source",
+    simulation_voltage_source_id: "sv1",
+    positive_source_port_id: "v1p",
+    negative_source_port_id: "v1n",
+    voltage: 5,
+  },
+  {
+    type: "simulation_voltage_source",
+    simulation_voltage_source_id: "sv2",
+    positive_source_port_id: "v2p",
+    negative_source_port_id: "v2n",
+    voltage: 3,
+  },
+  {
+    type: "source_trace",
+    source_trace_id: "t1",
+    connected_source_port_ids: ["v1n", "v2p"],
+    connected_source_net_ids: [],
+  },
+  { type: "source_net", source_net_id: "gnd", name: "GND" },
+  {
+    type: "source_trace",
+    source_trace_id: "t2",
+    connected_source_port_ids: ["v2n"],
+    connected_source_net_ids: ["gnd"],
+  },
+] as unknown as AnyCircuitElement[]
+
+test("stacked voltage sources keep their shared mid node (no self-shorted source)", () => {
+  const spiceString = circuitJsonToSpice(stackedSources).toSpiceString()
+
+  expect(spiceString).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    Vsv1 N2 N1 DC 5
+    Vsv2 N1 0 DC 3
+    .END"
+  `)
+
+  // Neither source may have identical + and - nodes (a self-short).
+  for (const line of spiceString.split("\n").filter((l) => l.startsWith("V"))) {
+    const [, nodePlus, nodeMinus] = line.split(/\s+/)
+    expect(nodePlus).not.toBe(nodeMinus)
+  }
+})


### PR DESCRIPTION
### Problem
The ground-detection pass added the net on **every** `simulation_voltage_source`'s negative terminal to the ground set (all mapped to node `0`). That is only correct when the terminal is actually ground — it breaks any floating or stacked source.

**Stacked sources** (V1 `TOP→MID`, V2 `MID→GND`) — the shared `MID` node collapses into `0`, and the upper source is emitted **self-shorted**:
```
Vsv1 N1 0 DC 5
Vsv2 0 0 DC 3      ← both terminals on node 0 (SPICE singular matrix / voltage-source loop)
```
**High-side source** (V `VCC→MID`, R `MID→GND`) — the load resistor collapses to `RR1 0 0` (shorted out).

### Fix (`lib/circuitJsonToSpice.ts`)
- Only use voltage-source negative terminals as the ground reference when no ground was found by name (an explicit `GND` net/port still wins).
- Skip any net that is **also** a source's *positive* terminal — that's a genuine internal node (e.g. the node between two stacked sources), so it keeps its own `N…` node instead of collapsing to `0`.
- A common ground shared by several sources (e.g. a buck converter's two supplies) is still detected.

After:
```
Vsv1 N2 N1 DC 5
Vsv2 N1 0 DC 3     ← MID (N1) preserved, only the real GND is node 0
```


