### PR TITLE
Add failing repro: one invalid component value discards the whole netlist

### DIFF
--- a/tests/examples/invalid-component-value.test.tsx
+++ b/tests/examples/invalid-component-value.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+import type { AnyCircuitElement } from "circuit-json"
+
+// One component (R2) has a missing/invalid value — `null` here, which is what
+// partial or hand-authored circuit JSON can realistically contain. The R/C/L
+// value formatters call `.toString()` on the raw value, so a null/undefined
+// value throws. The per-component loop has no error handling, so the throw
+// propagates and the ENTIRE netlist is discarded — the perfectly valid R1 is
+// lost too, and the caller gets nothing back.
+const circuitWithOneBadValue: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "r1",
+    name: "R1",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  },
+  {
+    type: "source_component",
+    source_component_id: "r2",
+    name: "R2",
+    ftype: "simple_resistor",
+    resistance: null,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r1a",
+    source_component_id: "r1",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r1b",
+    source_component_id: "r1",
+    pin_number: 2,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r2a",
+    source_component_id: "r2",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r2b",
+    source_component_id: "r2",
+    pin_number: 2,
+  },
+] as unknown as AnyCircuitElement[]
+
+// Failing on main: circuitJsonToSpice throws, so no netlist is produced at all.
+test.failing(
+  "a component with an invalid value does not discard the rest of the netlist",
+  () => {
+    const spice = circuitJsonToSpice(circuitWithOneBadValue).toSpiceString()
+    // The valid resistor must survive even though R2's value is invalid.
+    expect(spice).toContain("RR1")
+  },
+)


### PR DESCRIPTION
Repro for #47.

Repro for a crash where **one component with a missing/invalid value discards the entire netlist**.

`processSimpleResistor`/`Capacitor`/`Inductor` gate on `"resistance" in component` (etc.), which is `true` even when the value is `null`/`undefined`. The value then reaches `formatResistance`/`formatCapacitance`/`formatInductance`, which call `.toString()` on the raw value → `TypeError` for `null`/`undefined`. The per-component loop in `circuitJsonToSpice` has no error handling, so the throw propagates and **the whole netlist is lost** — including every valid component.

`null` is realistic input from partial / hand-authored / deserialized circuit JSON.

This PR adds a `test.failing` demonstrating it: a circuit with a valid `R1` and an `R2` whose `resistance` is `null` should still emit `R1`, but currently `circuitJsonToSpice` throws and returns nothing. The fix is in the stacked PR.

(Note: `formatSecondsForSpice` and `formatNumberForSpice` already guard with `if (!Number.isFinite(value)) …`; the R/C/L formatters just omit it.)

