### PR TITLE
Guard R/C/L value formatters against non-finite values

### DIFF
--- a/lib/processors/helpers.ts
+++ b/lib/processors/helpers.ts
@@ -1,12 +1,14 @@
 import type { SimulationSwitch } from "circuit-json"
 
 export function formatResistance(resistance: number): string {
+  if (!Number.isFinite(resistance)) return `${resistance}`
   if (resistance >= 1e6) return `${resistance / 1e6}MEG`
   if (resistance >= 1e3) return `${resistance / 1e3}K`
   return resistance.toString()
 }
 
 export function formatCapacitance(capacitance: number): string {
+  if (!Number.isFinite(capacitance)) return `${capacitance}`
   if (capacitance >= 1e-3) return `${capacitance * 1e3}M`
   if (capacitance >= 1e-6) return `${capacitance * 1e6}U`
   if (capacitance >= 1e-9) return `${capacitance * 1e9}N`
@@ -15,6 +17,7 @@ export function formatCapacitance(capacitance: number): string {
 }
 
 export function formatInductance(inductance: number): string {
+  if (!Number.isFinite(inductance)) return `${inductance}`
   if (inductance >= 1) return inductance.toString()
   if (inductance >= 1e-3) return `${inductance * 1e3}m`
   if (inductance >= 1e-6) return `${inductance * 1e6}u`

--- a/tests/examples/invalid-component-value.test.tsx
+++ b/tests/examples/invalid-component-value.test.tsx
@@ -1,0 +1,60 @@
+import { expect, test } from "bun:test"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+import type { AnyCircuitElement } from "circuit-json"
+
+// One component (R2) has a missing/invalid value — `null` here, which is what
+// partial or hand-authored circuit JSON can realistically contain. The R/C/L
+// value formatters call `.toString()` on the raw value, so a null/undefined
+// value throws. The per-component loop has no error handling, so the throw
+// propagates and the ENTIRE netlist is discarded — the perfectly valid R1 is
+// lost too, and the caller gets nothing back.
+const circuitWithOneBadValue: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "r1",
+    name: "R1",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  },
+  {
+    type: "source_component",
+    source_component_id: "r2",
+    name: "R2",
+    ftype: "simple_resistor",
+    resistance: null,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r1a",
+    source_component_id: "r1",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r1b",
+    source_component_id: "r1",
+    pin_number: 2,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r2a",
+    source_component_id: "r2",
+    pin_number: 1,
+  },
+  {
+    type: "source_port",
+    source_port_id: "r2b",
+    source_component_id: "r2",
+    pin_number: 2,
+  },
+] as unknown as AnyCircuitElement[]
+
+// Failing on main: circuitJsonToSpice throws, so no netlist is produced at all.
+test.failing(
+  "a component with an invalid value does not discard the rest of the netlist",
+  () => {
+    const spice = circuitJsonToSpice(circuitWithOneBadValue).toSpiceString()
+    // The valid resistor must survive even though R2's value is invalid.
+    expect(spice).toContain("RR1")
+  },
+)

--- a/tests/examples/invalid-component-value.test.tsx
+++ b/tests/examples/invalid-component-value.test.tsx
@@ -49,12 +49,8 @@ const circuitWithOneBadValue: AnyCircuitElement[] = [
   },
 ] as unknown as AnyCircuitElement[]
 
-// Failing on main: circuitJsonToSpice throws, so no netlist is produced at all.
-test.failing(
-  "a component with an invalid value does not discard the rest of the netlist",
-  () => {
-    const spice = circuitJsonToSpice(circuitWithOneBadValue).toSpiceString()
-    // The valid resistor must survive even though R2's value is invalid.
-    expect(spice).toContain("RR1")
-  },
-)
+test("a component with an invalid value does not discard the rest of the netlist", () => {
+  const spice = circuitJsonToSpice(circuitWithOneBadValue).toSpiceString()
+  // The valid resistor must survive even though R2's value is invalid.
+  expect(spice).toContain("RR1")
+})


### PR DESCRIPTION
Fixes #47.

Fix for #45.

`formatResistance` / `formatCapacitance` / `formatInductance` fell through to `value.toString()`, which throws for `null`/`undefined`. Since the per-component loop has no error handling, one bad value discarded the **entire** netlist.

This adds the **same non-finite guard the sibling helpers already use** — `formatSecondsForSpice` and `formatNumberForSpice` both start with `if (!Number.isFinite(value)) return \`${value}\``. The three R/C/L formatters just omitted it.

### Before
```
circuitJsonToSpice([R1=1k, R2 with resistance:null])  →  throws → whole netlist lost (R1 too)
```
### After
```
RR1 N1 N2 1K
RR2 N3 N4 null      ← R2's bad value is surfaced, but R1 (and the rest) survive
```

The repro test in #45 flips from `test.failing` to passing. Full suite green; no existing snapshot changes.

