### PR TITLE
Fix peak-to-peak voltage source conversion

### DIFF
--- a/lib/processors/process-simulation-voltage-sources.ts
+++ b/lib/processors/process-simulation-voltage-sources.ts
@@ -29,7 +29,8 @@ export const processSimulationVoltageSources = (
         const wave_shape = simSource.wave_shape
         if (wave_shape === "sinewave") {
           const v_offset = 0 // not provided in circuitJson
-          const v_peak = simSource.voltage ?? 0
+          const v_peak =
+            simSource.voltage ?? (simSource.peak_to_peak_voltage ?? 0) / 2
           const freq = simSource.frequency ?? 0
           const delay = 0 // not provided in circuitJson
           const damping_factor = 0 // not provided in circuitJson
@@ -41,7 +42,8 @@ export const processSimulationVoltageSources = (
           }
         } else if (wave_shape === "square") {
           const v_initial = 0
-          const v_pulsed = simSource.voltage ?? 0
+          const v_pulsed =
+            simSource.voltage ?? simSource.peak_to_peak_voltage ?? 0
           const freq = simSource.frequency ?? 0
           const period_from_freq = freq === 0 ? Infinity : 1 / freq
           const hasExplicitPeriod = simSource.period !== undefined

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "@types/bun": "^1.2.15",
     "bun-match-svg": "^0.0.13",
     "circuit-json": "^0.0.436",
-    "format-si-unit": "^0.0.7",
     "eecircuit-engine": "^1.5.2",
+    "format-si-unit": "^0.0.7",
     "tscircuit": "^0.0.936",
     "tsup": "^8.4.0"
   },

--- a/tests/unit/peak-to-peak-voltage-source.test.ts
+++ b/tests/unit/peak-to-peak-voltage-source.test.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement, SimulationVoltageSource } from "circuit-json"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+
+const getCircuitWithAcVoltageSource = (
+  voltageSource: Omit<
+    Extract<SimulationVoltageSource, { is_dc_source: false }>,
+    | "type"
+    | "simulation_voltage_source_id"
+    | "is_dc_source"
+    | "terminal1_source_port_id"
+    | "terminal2_source_port_id"
+  >,
+): AnyCircuitElement[] => [
+  {
+    type: "source_net",
+    source_net_id: "net_out",
+    name: "OUT",
+    member_source_group_ids: [],
+  } as AnyCircuitElement,
+  {
+    type: "source_net",
+    source_net_id: "net_gnd",
+    name: "GND",
+    member_source_group_ids: [],
+  } as AnyCircuitElement,
+  {
+    type: "source_port",
+    source_port_id: "source_pos",
+    name: "pos",
+    source_component_id: "source",
+  } as AnyCircuitElement,
+  {
+    type: "source_port",
+    source_port_id: "source_neg",
+    name: "neg",
+    source_component_id: "source",
+  } as AnyCircuitElement,
+  {
+    type: "source_trace",
+    source_trace_id: "trace_out",
+    connected_source_port_ids: ["source_pos"],
+    connected_source_net_ids: ["net_out"],
+  } as AnyCircuitElement,
+  {
+    type: "source_trace",
+    source_trace_id: "trace_gnd",
+    connected_source_port_ids: ["source_neg"],
+    connected_source_net_ids: ["net_gnd"],
+  } as AnyCircuitElement,
+  {
+    type: "simulation_voltage_source",
+    simulation_voltage_source_id: "source",
+    is_dc_source: false,
+    terminal1_source_port_id: "source_pos",
+    terminal2_source_port_id: "source_neg",
+    ...voltageSource,
+  } as AnyCircuitElement,
+]
+
+test("sine source derives peak amplitude from peak-to-peak voltage", () => {
+  const netlist = circuitJsonToSpice(
+    getCircuitWithAcVoltageSource({
+      peak_to_peak_voltage: 10,
+      frequency: 60,
+      wave_shape: "sinewave",
+    }),
+  )
+
+  expect(netlist.toSpiceString()).toContain("Vsource N1 0 SIN(0 5 60 0 0 0)")
+})
+
+test("square source uses peak-to-peak voltage as its high level", () => {
+  const netlist = circuitJsonToSpice(
+    getCircuitWithAcVoltageSource({
+      peak_to_peak_voltage: 10,
+      frequency: 1000,
+      wave_shape: "square",
+    }),
+  )
+
+  expect(netlist.toSpiceString()).toContain(
+    "Vsource N1 0 PULSE(0 10 0 1n 1n 500u 1m)",
+  )
+})
+
+test("explicit voltage takes precedence over peak-to-peak voltage", () => {
+  const netlist = circuitJsonToSpice(
+    getCircuitWithAcVoltageSource({
+      voltage: 3,
+      peak_to_peak_voltage: 10,
+      frequency: 60,
+      wave_shape: "sinewave",
+    }),
+  )
+
+  expect(netlist.toSpiceString()).toContain("Vsource N1 0 SIN(0 3 60 0 0 0)")
+})


### PR DESCRIPTION
## Summary

- derive sine-wave peak amplitude from `peak_to_peak_voltage / 2` when `voltage` is absent
- use `peak_to_peak_voltage` as the high level for supported unipolar square waves
- preserve explicit `voltage` precedence for backward compatibility
- add regression coverage for sine, square, and mixed-property inputs

## Root cause

tscircuit core already writes `peak_to_peak_voltage` into `SimulationAcVoltageSource`, and the circuit-json schema includes the field. The SPICE converter only read `voltage`, so a source declared with only `peakToPeakVoltage` became a zero-amplitude waveform such as `SIN(0 0 60 ...)`.

This could silently disable AC-input power supplies, bridge rectifiers, transformer excitation, inverter references, and other analog simulations while still producing a successful simulation.

## Validation

- `bun test` — 52 pass, 0 fail
- `bun run typecheck`
- `bun run format:check`
- `git diff --check`
