### PR TITLE
Generate DC operating-point SPICE analyses

### DIFF
--- a/lib/circuitJsonToSpice.ts
+++ b/lib/circuitJsonToSpice.ts
@@ -27,6 +27,7 @@ import { processSimulationCurrentSources } from "./processors/process-simulation
 import { processSimulationExperiment } from "./processors/process-simulation-experiment"
 import { processSimulationOpAmps } from "./processors/process-simulation-op-amp"
 import { processSimulationSpiceSubcircuits } from "./processors/process-simulation-spice-subcircuits"
+import { CircuitJsonToSpiceError } from "./errors"
 
 export function circuitJsonToSpice(
   circuitJson: AnyCircuitElement[],
@@ -52,6 +53,9 @@ export function circuitJsonToSpice(
   const simulationSpiceSubcircuits = circuitJson.filter(
     (elm) => elm.type === "simulation_spice_subcircuit",
   ) as SimulationSpiceSubcircuit[]
+  const modeledSourceComponentIds = new Set(
+    simulationSpiceSubcircuits.map((model) => model.source_component_id),
+  )
   const simulationSwitchMap = new Map<string, SimulationSwitch>()
 
   for (const simSwitch of simulationSwitches) {
@@ -220,6 +224,22 @@ export function circuitJsonToSpice(
       let spiceComponent: SpiceComponent | null = null
 
       switch ((component as { ftype: string }).ftype) {
+        case "simple_chip": {
+          const boundarySetting = (
+            component as { is_simulation_boundary?: boolean }
+          ).is_simulation_boundary
+          if (
+            boundarySetting === false &&
+            !modeledSourceComponentIds.has(component.source_component_id)
+          ) {
+            throw new CircuitJsonToSpiceError(
+              "missing_model",
+              `Missing SPICE model for ${component.name ?? component.source_component_id}`,
+              "Add a spiceModel to the chip or set simulationBoundary to stop the analog simulation at this component.",
+            )
+          }
+          break
+        }
         case "simple_resistor": {
           spiceComponent = processSimpleResistor({ component, nodes })
           break

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -1,0 +1,20 @@
+export type CircuitJsonToSpiceErrorCode =
+  | "missing_model"
+  | "unsupported_analysis"
+  | "invalid_netlist"
+
+export class CircuitJsonToSpiceError extends Error {
+  code: CircuitJsonToSpiceErrorCode
+  diagnostics?: string
+
+  constructor(
+    code: CircuitJsonToSpiceErrorCode,
+    message: string,
+    diagnostics?: string,
+  ) {
+    super(message)
+    this.name = "CircuitJsonToSpiceError"
+    this.code = code
+    this.diagnostics = diagnostics
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,6 +3,7 @@ export { SpiceNetlist } from "./spice-classes/SpiceNetlist"
 export { SpiceComponent } from "./spice-classes/SpiceComponent"
 export { SpiceSubcircuit } from "./spice-classes/SpiceSubcircuit"
 export { convertSpiceNetlistToString } from "./spice-utils/convertSpiceNetlistToString"
+export * from "./errors"
 
 // Export all SPICE commands
 export * from "./spice-commands"

--- a/lib/processors/process-simulation-experiment.ts
+++ b/lib/processors/process-simulation-experiment.ts
@@ -7,6 +7,7 @@ import type {
 import { SpiceComponent } from "lib/spice-classes/SpiceComponent"
 import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
 import { VoltageSourceCommand } from "lib/spice-commands"
+import { CircuitJsonToSpiceError } from "lib/errors"
 import { formatNumberForSpice, sanitizeIdentifier } from "./helpers"
 
 const spiceOptionOrder = ["method", "reltol", "abstol", "vntol"] as const
@@ -26,6 +27,7 @@ interface CurrentProbeVectorMapping {
   sense_voltage_source_name: string
   positive_node_name: string
   negative_node_name: string
+  source_component_id?: string
 }
 
 const getPortIdFromNetId = (sourceTraces: SourceTrace[], netId: string) => {
@@ -75,8 +77,18 @@ export const processSimulationExperiment = (
   if (!simExperiment) return
 
   const isTransientExperiment =
-    simExperiment.experiment_type?.includes("transient") ?? false
-  const transientProbeVectors = new Set<string>()
+    simExperiment.experiment_type === "spice_transient_analysis"
+  const isOperatingPointExperiment =
+    simExperiment.experiment_type === "spice_dc_operating_point"
+
+  if (!isTransientExperiment && !isOperatingPointExperiment) {
+    throw new CircuitJsonToSpiceError(
+      "unsupported_analysis",
+      `Unsupported simulation analysis: ${simExperiment.experiment_type}`,
+    )
+  }
+
+  const probeVectors = new Set<string>()
 
   const spiceOptions = simExperiment.spice_options
   if (spiceOptions) {
@@ -118,7 +130,7 @@ export const processSimulationExperiment = (
         })
         if (referenceNodeName && referenceNodeName !== "0") {
           const spiceVector = `V(${signalNodeName},${referenceNodeName})`
-          transientProbeVectors.add(spiceVector)
+          probeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -128,7 +140,7 @@ export const processSimulationExperiment = (
           })
         } else if (signalNodeName !== "0") {
           const spiceVector = `V(${signalNodeName})`
-          transientProbeVectors.add(spiceVector)
+          probeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -141,7 +153,7 @@ export const processSimulationExperiment = (
         // Single-ended probe
         if (signalNodeName !== "0") {
           const spiceVector = `V(${signalNodeName})`
-          transientProbeVectors.add(spiceVector)
+          probeVectors.add(spiceVector)
           probeVectorMappings.push({
             simulation_voltage_probe_id: probe.simulation_voltage_probe_id,
             name: probe.name,
@@ -152,7 +164,7 @@ export const processSimulationExperiment = (
       }
     }
 
-    if (probeVectorMappings.length > 0 && isTransientExperiment) {
+    if (probeVectorMappings.length > 0) {
       for (const mapping of probeVectorMappings) {
         netlist.metadataComments.push(
           `* tscircuit_probe ${JSON.stringify(mapping)}`,
@@ -207,9 +219,7 @@ export const processSimulationExperiment = (
         ]),
       )
 
-      if (isTransientExperiment) {
-        transientProbeVectors.add(spiceVector)
-      }
+      probeVectors.add(spiceVector)
       currentProbeVectorMappings.push({
         simulation_current_probe_id: probe.simulation_current_probe_id,
         name: probe.name,
@@ -217,6 +227,7 @@ export const processSimulationExperiment = (
         sense_voltage_source_name: spiceSenseVoltageSourceName,
         positive_node_name: positiveNodeName,
         negative_node_name: negativeNodeName,
+        source_component_id: probe.source_component_id,
       })
     }
 
@@ -229,17 +240,31 @@ export const processSimulationExperiment = (
     }
   }
 
-  if (transientProbeVectors.size > 0 && isTransientExperiment) {
-    const probeVectors = [...transientProbeVectors].join(" ")
-    netlist.printStatements.push(`.PRINT TRAN ${probeVectors}`)
-    netlist.saveStatements.push(`.SAVE ${probeVectors}`)
+  if (probeVectors.size > 0) {
+    const vectors = [...probeVectors].join(" ")
+    netlist.printStatements.push(
+      `.PRINT ${isTransientExperiment ? "TRAN" : "OP"} ${vectors}`,
+    )
+    netlist.saveStatements.push(`.SAVE ${vectors}`)
+  }
+
+  if (isOperatingPointExperiment) {
+    netlist.operatingPointCommand = ".op"
+    return
   }
 
   const timePerStep = simExperiment.time_per_step
   const endTime = simExperiment.end_time_ms
   const startTimeMs = simExperiment.start_time_ms
 
-  if (timePerStep && endTime) {
+  if (!timePerStep || !endTime) {
+    throw new CircuitJsonToSpiceError(
+      "invalid_netlist",
+      "Transient analysis requires both time_per_step and end_time_ms",
+    )
+  }
+
+  {
     // circuit-json values are in ms, SPICE requires seconds
     const startTime = (startTimeMs ?? 0) / 1000
 

--- a/lib/processors/process-simulation-spice-subcircuits.ts
+++ b/lib/processors/process-simulation-spice-subcircuits.ts
@@ -2,6 +2,7 @@ import type { SimulationSpiceSubcircuit } from "circuit-json"
 import { SpiceComponent } from "lib/spice-classes/SpiceComponent"
 import type { SpiceNetlist } from "lib/spice-classes/SpiceNetlist"
 import { SubcircuitCallCommand } from "lib/spice-commands"
+import { CircuitJsonToSpiceError } from "lib/errors"
 
 export function parseSpiceSubckt(
   source: string,
@@ -43,7 +44,13 @@ export function processSimulationSpiceSubcircuits(
       simulationSpiceSubcircuit.subcircuit_source,
     )
 
-    if (!parsedSubckt) continue
+    if (!parsedSubckt) {
+      throw new CircuitJsonToSpiceError(
+        "invalid_netlist",
+        `Invalid SPICE subcircuit for ${simulationSpiceSubcircuit.source_component_id}`,
+        "Expected a .SUBCKT declaration with at least one pin",
+      )
+    }
 
     const { modelName, pinNames } = parsedSubckt
 

--- a/lib/spice-classes/SpiceNetlist.ts
+++ b/lib/spice-classes/SpiceNetlist.ts
@@ -12,6 +12,7 @@ export class SpiceNetlist {
   optionStatements: string[]
   metadataComments: string[]
   tranCommand: string | null
+  operatingPointCommand: string | null
   printStatements: string[]
   saveStatements: string[]
 
@@ -25,6 +26,7 @@ export class SpiceNetlist {
     this.optionStatements = []
     this.metadataComments = []
     this.tranCommand = null
+    this.operatingPointCommand = null
     this.printStatements = []
     this.saveStatements = []
   }

--- a/lib/spice-utils/convertSpiceNetlistToString.ts
+++ b/lib/spice-utils/convertSpiceNetlistToString.ts
@@ -51,6 +51,13 @@ export const convertSpiceNetlistToString = (netlist: SpiceNetlist): string => {
     lines.push(netlist.tranCommand)
   }
 
+  if (
+    netlist.operatingPointCommand &&
+    !lines.some((l) => l.trim().toLowerCase().startsWith(".op"))
+  ) {
+    lines.push(netlist.operatingPointCommand)
+  }
+
   // End with .END
   lines.push(".END")
 

--- a/tests/integration/simulation.test.ts
+++ b/tests/integration/simulation.test.ts
@@ -82,6 +82,99 @@ test("simulate resistor divider containing a zero-ohm resistor", async () => {
   expect(result.variableNames).toContain("v(n1)")
 })
 
+test("simulate a generated operating-point netlist", async () => {
+  const circuitJson = [
+    {
+      type: "source_component",
+      source_component_id: "R1",
+      name: "R1",
+      ftype: "simple_resistor",
+      resistance: 1000,
+    },
+    {
+      type: "source_port",
+      source_port_id: "R1_p1",
+      source_component_id: "R1",
+      name: "p1",
+      pin_number: 1,
+    },
+    {
+      type: "source_port",
+      source_port_id: "R1_p2",
+      source_component_id: "R1",
+      name: "p2",
+      pin_number: 2,
+    },
+    {
+      type: "source_port",
+      source_port_id: "V1_pos",
+      source_component_id: "V1",
+      name: "pos",
+    },
+    {
+      type: "source_port",
+      source_port_id: "V1_neg",
+      source_component_id: "V1",
+      name: "neg",
+    },
+    {
+      type: "source_net",
+      source_net_id: "vin",
+      name: "VIN",
+      member_source_group_ids: [],
+    },
+    {
+      type: "source_net",
+      source_net_id: "gnd",
+      name: "GND",
+      member_source_group_ids: [],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "trace_vin",
+      connected_source_port_ids: ["V1_pos", "R1_p1"],
+      connected_source_net_ids: ["vin"],
+    },
+    {
+      type: "source_trace",
+      source_trace_id: "trace_gnd",
+      connected_source_port_ids: ["V1_neg", "R1_p2"],
+      connected_source_net_ids: ["gnd"],
+    },
+    {
+      type: "simulation_voltage_source",
+      simulation_voltage_source_id: "source1",
+      positive_source_port_id: "V1_pos",
+      negative_source_port_id: "V1_neg",
+      voltage: 5,
+    },
+    {
+      type: "simulation_voltage_probe",
+      simulation_voltage_probe_id: "probe1",
+      signal_input_source_port_id: "R1_p1",
+      name: "VIN",
+    },
+    {
+      type: "simulation_experiment",
+      simulation_experiment_id: "op1",
+      name: "Bias point",
+      experiment_type: "spice_dc_operating_point",
+    },
+  ] as AnyCircuitElement[]
+
+  const spice = circuitJsonToSpice(circuitJson).toSpiceString()
+  expect(spice).toContain(".PRINT OP V(VIN)")
+  expect(spice).toContain(".op")
+
+  const sim = new Simulation()
+  await sim.start()
+  sim.setNetList(spice)
+  const result = await sim.runSim()
+  const vin = result.data.find((entry) => entry.name.toLowerCase() === "v(vin)")
+
+  expect(vin?.values[0]).toBeCloseTo(5)
+})
+
 const roundNumber = (value: number, decimals: number) => {
   const factor = 10 ** decimals
   return Math.round(value * factor) / factor

--- a/tests/unit/current-probe.test.ts
+++ b/tests/unit/current-probe.test.ts
@@ -163,7 +163,7 @@ test("net-based current probe resolves source net ids to node names", () => {
   )
 })
 
-test("inline current probe sense source remains in non-transient netlists without transient output", () => {
+test("inline current probe is emitted as operating-point output", () => {
   const circuitJson: AnyCircuitElement[] = [
     ...baseCircuit.filter(
       (element) => element.type !== "simulation_experiment",
@@ -177,6 +177,7 @@ test("inline current probe sense source remains in non-transient netlists withou
     currentProbe({
       type: "simulation_current_probe",
       simulation_current_probe_id: "cp_dc",
+      source_component_id: "AM1",
       positive_source_port_id: "AM1_p1",
       negative_source_port_id: "AM1_p2",
     }),
@@ -187,7 +188,10 @@ test("inline current probe sense source remains in non-transient netlists withou
 
   expect(spiceString).toContain("Vsense_cp_dc N1 N2 DC 0")
   expect(spiceString).not.toContain(".PRINT TRAN")
-  expect(spiceString).not.toContain(".SAVE")
+  expect(spiceString).toContain(".PRINT OP I(Vsense_cp_dc)")
+  expect(spiceString).toContain(".SAVE I(Vsense_cp_dc)")
+  expect(spiceString).toContain(".op")
+  expect(spiceString).toContain('"source_component_id":"AM1"')
 })
 
 test("multiple current probes share one .PRINT and one .SAVE current output", () => {

--- a/tests/unit/operating-point-simulation.test.ts
+++ b/tests/unit/operating-point-simulation.test.ts
@@ -1,0 +1,102 @@
+import { expect, test } from "bun:test"
+import type { AnyCircuitElement } from "circuit-json"
+import { circuitJsonToSpice } from "lib/circuitJsonToSpice"
+import { CircuitJsonToSpiceError } from "lib/errors"
+
+const operatingPointCircuit: AnyCircuitElement[] = [
+  {
+    type: "source_component",
+    source_component_id: "R1",
+    name: "R1",
+    ftype: "simple_resistor",
+    resistance: 1000,
+  } as AnyCircuitElement,
+  {
+    type: "source_port",
+    source_port_id: "R1_p1",
+    source_component_id: "R1",
+    name: "p1",
+    pin_number: 1,
+  } as AnyCircuitElement,
+  {
+    type: "source_port",
+    source_port_id: "R1_p2",
+    source_component_id: "R1",
+    name: "GND",
+    pin_number: 2,
+  } as AnyCircuitElement,
+  {
+    type: "simulation_voltage_probe",
+    simulation_voltage_probe_id: "probe1",
+    signal_input_source_port_id: "R1_p1",
+    name: "VOUT",
+  } as AnyCircuitElement,
+  {
+    type: "simulation_experiment",
+    simulation_experiment_id: "se1",
+    name: "Bias point",
+    experiment_type: "spice_dc_operating_point",
+  } as AnyCircuitElement,
+]
+
+test("operating-point experiment emits probe metadata, OP output, and .op", () => {
+  const spiceString = circuitJsonToSpice(operatingPointCircuit).toSpiceString()
+
+  expect(spiceString).toMatchInlineSnapshot(`
+    "* Circuit JSON to SPICE Netlist
+    RR1 VOUT N1 1K
+    * tscircuit_probe {\"simulation_voltage_probe_id\":\"probe1\",\"name\":\"VOUT\",\"spice_vector\":\"V(VOUT)\",\"source_node_name\":\"VOUT\"}
+    .PRINT OP V(VOUT)
+    .SAVE V(VOUT)
+    .op
+    .END"
+  `)
+  expect(spiceString).not.toContain(".tran")
+  expect(spiceString).not.toContain("UIC")
+})
+
+test("unmodeled chips report missing_model unless explicitly marked as a boundary", () => {
+  const chip = {
+    type: "source_component",
+    source_component_id: "U1",
+    name: "U1",
+    ftype: "simple_chip",
+    is_simulation_boundary: false,
+  } as AnyCircuitElement
+
+  try {
+    circuitJsonToSpice([...operatingPointCircuit, chip])
+    throw new Error("Expected conversion to fail")
+  } catch (error) {
+    expect(error).toBeInstanceOf(CircuitJsonToSpiceError)
+    expect((error as CircuitJsonToSpiceError).code).toBe("missing_model")
+    expect((error as Error).message).toContain("U1")
+  }
+
+  const boundaryChip = {
+    ...chip,
+    is_simulation_boundary: true,
+  } as unknown as AnyCircuitElement
+  expect(() =>
+    circuitJsonToSpice([...operatingPointCircuit, boundaryChip]),
+  ).not.toThrow()
+})
+
+test("unsupported analyses report unsupported_analysis", () => {
+  const circuit = operatingPointCircuit.map((element) =>
+    element.type === "simulation_experiment"
+      ? ({
+          ...element,
+          experiment_type: "spice_ac_analysis",
+        } as AnyCircuitElement)
+      : element,
+  )
+
+  try {
+    circuitJsonToSpice(circuit)
+    throw new Error("Expected conversion to fail")
+  } catch (error) {
+    expect(error).toBeInstanceOf(CircuitJsonToSpiceError)
+    expect((error as CircuitJsonToSpiceError).code).toBe("unsupported_analysis")
+  }
+})

--- a/tests/unit/transient-simulation.test.ts
+++ b/tests/unit/transient-simulation.test.ts
@@ -83,7 +83,7 @@ test("does not add .tran if a component already provides one", () => {
   `)
 })
 
-test("circuit with incomplete simulation experiment does not add .tran command", () => {
+test("circuit with incomplete transient experiment reports an invalid netlist", () => {
   const circuitJson: AnyCircuitElement[] = [
     {
       type: "simulation_experiment",
@@ -96,14 +96,9 @@ test("circuit with incomplete simulation experiment does not add .tran command",
     } as AnyCircuitElement,
   ]
 
-  const netlist = circuitJsonToSpice(circuitJson)
-  const spiceString = netlist.toSpiceString()
-
-  expect(spiceString).not.toContain(".tran")
-  expect(spiceString).toMatchInlineSnapshot(`
-    "* Circuit JSON to SPICE Netlist
-    .END"
-  `)
+  expect(() => circuitJsonToSpice(circuitJson)).toThrow(
+    "Transient analysis requires both time_per_step and end_time_ms",
+  )
 })
 
 test("circuit with simulation experiment and 0 start time adds .tran command", () => {


### PR DESCRIPTION
## Summary

- generate `.op`, `.PRINT OP`, `.SAVE`, and probe metadata for DC operating-point experiments
- preserve the existing transient command and `UIC` behavior for transient experiments
- report classified converter errors for unsupported analyses, incomplete transient settings, invalid subcircuits, and explicitly non-boundary chips with no model
- keep legacy Circuit JSON compatible when the boundary field is absent

## Stack and merge order

1. Schema/result contract: https://github.com/tscircuit/circuit-json/pull/646
2. Public props: https://github.com/tscircuit/props/pull/730
3. `.op` netlist generation (this PR): https://github.com/tscircuit/circuit-json-to-spice/pull/50
4. ngspice execution/result conversion: https://github.com/tscircuit/ngspice-spice-engine/pull/25
5. SVG results and diagnostics: https://github.com/tscircuit/circuit-to-svg/pull/622
6. Core integration: https://github.com/tscircuit/core/pull/2682

## Validation

- `bun test` (56 passing, including a real ngspice `.op` integration test)
- `bun run typecheck`
- `bun run build`
- `bun run format:check`
